### PR TITLE
Fixes misc issues related to memory management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ __pycache__
 # Generated files
 include/psl/psl.hpp
 include/psl/config.hpp
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,10 @@ project(${LOCAL_PROJECT} VERSION 0.0.1 LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-option(avx2 "support avx2" FALSE)
-option(examples "build examples" FALSE)
-option(develop_mode "develop mode" FALSE)
+option(LITMUS_EXAMPLES "build examples" FALSE)
+option(LITMUS_DEVELOP_MODE "develop mode" FALSE)
 
-if(develop_mode)
+if(LITMUS_DEVELOP_MODE)
 	SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
@@ -68,7 +67,7 @@ list(APPEND LITMUS_INCLUDES_DIRECTORIES include)
 ### Setup	 																										###
 #######################################################################################################################
 
-if(NOT ${STRTYPE_PROJECT})
+if(NOT TARGET strtype)
 	add_subdirectory(extern/strtype)
 else()
 	message(STATUS "found already existing strtype library, using the provided one")
@@ -83,7 +82,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(${LOCAL_PROJECT} PUBLIC Threads::Threads strtype)
 
-if(develop_mode)
+if(LITMUS_DEVELOP_MODE)
 	# -Wno-error=terminate is silenced globally due to constent expressions not figuring out that they are not runtime, and 
 	# so warn of throws in noexcept marked functions.
 
@@ -96,6 +95,6 @@ if(develop_mode)
 		)
 endif()
 
-if(examples)
+if(LITMUS_EXAMPLES)
 	add_subdirectory(examples)
 endif()

--- a/examples/source/basic_tests.cpp
+++ b/examples/source/basic_tests.cpp
@@ -51,8 +51,8 @@ auto basic_test = suite<"basic", "cat0", "cat1">() = []() {
 		true) == true;
 	expect(5) == 5;
 	require(5) == 5;
-	expect(5) != 5;
-	require(5) != 5;
+	expect(6) != 5;
+	require(6) != 5;
 	expect(5) == 5;
 };
 

--- a/include/litmus/details/cache.hpp
+++ b/include/litmus/details/cache.hpp
@@ -36,17 +36,7 @@ namespace litmus
 			};
 
 		  public:
-			cache_t()
-			{
-				if(m_RefCount == 0) m_Data = new data_t();
-				++m_RefCount;
-			}
-
-			~cache_t()
-			{
-				if(--m_RefCount == 0) delete(m_Data);
-			}
-
+			cache_t()				= default;
 			cache_t(cache_t const&) = delete;
 			cache_t(cache_t&&)		= delete;
 
@@ -57,10 +47,9 @@ namespace litmus
 			const file_t& get(const std::string& file) const;
 
 		  private:
-			static data_t* m_Data;
-			static unsigned m_RefCount;
+			mutable data_t m_Data{};
 		};
 
-		const cache_t cache;
+		extern cache_t cache;
 	} // namespace internal
 } // namespace litmus

--- a/include/litmus/details/cache.hpp
+++ b/include/litmus/details/cache.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "exceptions.hpp"
 
 namespace litmus
 {
@@ -13,16 +14,12 @@ namespace litmus
 		{
 		  public:
 			file_t(const std::string& filename);
-			auto begin() noexcept -> std::vector<std::string_view>::iterator { return std::begin(m_Lines); }
-			auto begin() const noexcept -> std::vector<std::string_view>::const_iterator { return std::begin(m_Lines); }
-			auto cbegin() const noexcept -> std::vector<std::string_view>::const_iterator
-			{
-				return std::cbegin(m_Lines);
-			}
-			auto end() noexcept -> std::vector<std::string_view>::iterator { return std::end(m_Lines); }
-			auto end() const noexcept -> std::vector<std::string_view>::const_iterator { return std::end(m_Lines); }
-			auto cend() const noexcept -> std::vector<std::string_view>::const_iterator { return std::cend(m_Lines); }
 
+			auto substr(size_t line, size_t offset = 0) const -> std::string_view
+			{
+				except(line > m_LinePos.size() || m_LinePos[line] + offset > m_Content.size(), std::range_error{"Out of bounds access"});
+				return static_cast<std::string_view>(m_Content).substr(m_LinePos[line] + offset);
+			}
 		  private:
 			std::string m_Content;
 			std::vector<size_t> m_LinePos;

--- a/include/litmus/details/runner.hpp
+++ b/include/litmus/details/runner.hpp
@@ -4,7 +4,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <litmus/details/test_result.hpp>
 #include <litmus/details/utility.hpp>
 
 namespace litmus
@@ -30,6 +29,8 @@ namespace litmus
 		{
 			return uuid<typename std::decay<Ts>::type...>;
 		}
+
+		struct test_result_t;
 
 		struct runner_t
 		{

--- a/include/litmus/details/scope.hpp
+++ b/include/litmus/details/scope.hpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include <typeinfo>
 #include <tuple>
+#include <iostream>
 
 #include <litmus/details/context.hpp>
 #include <litmus/details/source_location.hpp>

--- a/include/litmus/details/utility.hpp
+++ b/include/litmus/details/utility.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <type_traits>
+#include <numeric>
 
 #include "strtype/strtype.hpp"
 

--- a/include/litmus/litmus.hpp
+++ b/include/litmus/litmus.hpp
@@ -8,6 +8,7 @@
 
 #include <litmus/details/verbosity.hpp>
 #include <litmus/details/cache.hpp>
+#include <litmus/details/runner.hpp>
 
 
 namespace litmus

--- a/source/details/cache.cpp
+++ b/source/details/cache.cpp
@@ -1,9 +1,6 @@
 #include <litmus/details/cache.hpp>
 #include <litmus/details/source_location.hpp>
 
-unsigned litmus::internal::cache_t::m_RefCount						 = 0;
-litmus::internal::cache_t::data_t* litmus::internal::cache_t::m_Data = nullptr;
-
 #include <algorithm>
 #include <fstream>
 
@@ -54,6 +51,6 @@ file_t::file_t(const std::string& filename)
 
 const file_t& cache_t::get(const std::string& file) const
 {
-	std::scoped_lock lock{m_Data->mutex};
-	return m_Data->files.try_emplace(file, file).first->second;
+	std::scoped_lock lock{m_Data.mutex};
+	return m_Data.files.try_emplace(file, file).first->second;
 }

--- a/source/litmus.cpp
+++ b/source/litmus.cpp
@@ -208,6 +208,7 @@ auto litmus::run(int argc, char* argv[],
 		formatter->set_stream(std::cout, true);
 	else
 	{
+		// todo this needs a delete..
 		filestream = new std::ofstream(output_file);
 		formatter->set_stream(*filestream, false);
 	}


### PR DESCRIPTION
On MSVC we get a false positive on a memory leak, we fix this by removing `std::async`
rewrote the source code analyzer to be able to handle source parsing just a tiny bit better
renamed the cmake options to be more unique.